### PR TITLE
Support many values per year + performance (MOSJ)

### DIFF
--- a/src/no/npolar/data/api/Labels.java
+++ b/src/no/npolar/data/api/Labels.java
@@ -2,8 +2,8 @@ package no.npolar.data.api;
 
 import java.util.Map;
 import java.util.HashMap;
-import java.util.Locale;
-import java.util.ResourceBundle;
+//import java.util.Locale;
+//import java.util.ResourceBundle;
 
 /**
  * Provides access to human-readable, localized translations of service identifier
@@ -16,6 +16,22 @@ import java.util.ResourceBundle;
  */
 public class Labels {
     public static Map<String, String> norm = new HashMap<String, String>();
+    
+    public static final String TIME_SERIES_PREFIX_0 = "timeseries.";
+    public static final String TIME_SERIES_UNIT_0 = TIME_SERIES_PREFIX_0 + "unit";
+    public static final String TIME_SERIES_TITLE_0 = TIME_SERIES_PREFIX_0 + "title";
+    
+    public static final String TIME_SERIES_POINT_PREFIX_0 = TIME_SERIES_PREFIX_0 + "point.";
+    public static final String TIME_SERIES_POINT_MEDIAN_0 = TIME_SERIES_POINT_PREFIX_0 + "median";
+    public static final String TIME_SERIES_POINT_ERROR_0 = TIME_SERIES_POINT_PREFIX_0 + "error";
+    
+    public static final String TIME_SERIES_POINT_VALUE_PREFIX_0 = TIME_SERIES_POINT_PREFIX_0 + "value.";
+    public static final String TIME_SERIES_POINT_VALUE_LOW_0 = TIME_SERIES_POINT_VALUE_PREFIX_0 + "low";
+    public static final String TIME_SERIES_POINT_VALUE_HIGH_0 = TIME_SERIES_POINT_VALUE_PREFIX_0 + "high";
+    public static final String TIME_SERIES_POINT_VALUE_MIN_0 = TIME_SERIES_POINT_VALUE_PREFIX_0 + "min";
+    public static final String TIME_SERIES_POINT_VALUE_MAX_0 = TIME_SERIES_POINT_VALUE_PREFIX_0 + "max";
+    public static final String TIME_SERIES_POINT_VALUE_MEDIAN_0 = TIME_SERIES_POINT_VALUE_PREFIX_0 + "max";
+    public static final String TIME_SERIES_POINT_VALUE_ERROR_0 = TIME_SERIES_POINT_VALUE_PREFIX_0 + "max";
     
     public static final String PUB_REF_EDITOR_0 = "publication.reference.editor";
     public static final String PUB_REF_EDITORS_0 = "publication.reference.editors";

--- a/src/no/npolar/data/api/Labels.properties
+++ b/src/no/npolar/data/api/Labels.properties
@@ -230,5 +230,17 @@ location.arctic.eastern_barents_sea = Eastern Barents Sea
 location.arctic.northern_barents_sea = Northern Barents Sea
 location.arctic.svalbard.barents\u00f8ya = Svalbard - Barents\u00f8ya
 
+#
+# Time series
+#
+timeseries.unit = Unit
+timeseries.title = Series name
+timeseries.point.error = Error
+timeseries.point.median = Median
+timeseries.point.value.low = Low
+timeseries.point.value.high = High
+timeseries.point.value.min = Min.
+timeseries.point.value.max = Max.
+
 DATA_COUNTRIES_0 = AF:Afghanistan|AL:Albania|DZ:Algeria|AD:Andorra|AO:Angola|AG:Antigua and Barbuda|AR:Argentina|AM:Armenia|AU:Australia|AT:Austria|AZ:Azerbaijan|BS:Bahamas|BH:Bahrain|BD:Bangladesh|BB:Barbados|BY:Belarus|BE:Belgium|BZ:Belize|BJ:Benin|BT:Bhutan|BO:Bolivia|BA:Bosnia and Herzegovina|BW:Botswana|BR:Brazil|BN:Brunei|BG:Bulgaria|BF:Burkina Faso|BI:Burundi|KH:Cambodia|CM:Cameroon|CA:Canada|CV:Cape Verde|CF:Central African Republic|TD:Chad|CL:Chile|CN:China|CO:Colombia|KM:Comoros|CG:Congo, Republic of the (Congo-Brazzaville)|CD:Congo, The Democratic Republic of The (Congo-Kinshasa)|CK:Cook Islands|CR:Costa Rica|CI:Cote D'ivoire|HR:Croatia|CU:Cuba|CY:Cyprus|CZ:Czech Republic|DK:Denmark|DJ:Djibouti|DM:Dominica|DO:Dominican Republic|EC:Ecuador|EG:Egypt|SV:El Salvador|GQ:Equatorial Guinea|ER:Eritrea|EE:Estonia|ET:Ethiopia|FJ:Fiji|FI:Finland|FR:France|GA:Gabon|GM:Gambia|GE:Georgia|DE:Germany|GH:Ghana|GR:Greece|GD:Grenada|GT:Guatemala|GN:Guinea|GW:Guinea-Bissau|GY:Guyana|HT:Haiti|VA:Vatican City State (Holy See)|HN:Honduras|HU:Hungary|IS:Iceland|IN:India|ID:Indonesia|IR:Iran|IQ:Iraq|IE:Ireland|IL:Israel|IT:Italy|JM:Jamaica|JP:Japan|JO:Jordan|KZ:Kazakhstan|KE:Kenya|KI:Kiribati|KP:Korea, Democratic People's Republic of (North)|KR:Korea, Republic of|XK:Kosovo|KW:Kuwait|KG:Kyrgyzstan|LA:Lao People's Democratic Republic (Laos)|LV:Latvia|LB:Lebanon|LS:Lesotho|LR:Liberia|LY:Libya|LI:Liechtenstein|LT:Lithuania|LU:Luxembourg|MK:Macedonia|MG:Madagascar|MW:Malawi|MY:Malaysia|MV:Maldives|ML:Mali|MT:Malta|MH:Marshall Islands|MR:Mauritania|MU:Mauritius|MX:Mexico|FM:Micronesia, Federated States of|MD:Moldova, Republic of|MC:Monaco|MN:Mongolia|ME:Montenegro|MA:Morocco|MZ:Mozambique|MM:Myanmar|NA:Namibia|NR:Nauru|NP:Nepal|NL:Netherlands|NZ:New Zealand|NI:Nicaragua|NE:Niger|NG:Nigeria|NU:Niue|NO:Norway|OM:Oman|PK:Pakistan|PW:Palau|PS:Palestine|PA:Panama|PG:Papua New Guinea|PY:Paraguay|PE:Peru|PH:Philippines|PL:Poland|PT:Portugal|QA:Qatar|RO:Romania|RU:Russia|RW:Rwanda|KN:Saint Kitts and Nevis|LC:Saint Lucia|VC:Saint Vincent and The Grenadines|WS:Samoa|SM:San Marino|ST:Sao Tome and Principe|SA:Saudi Arabia|SN:Senegal|RS:Serbia|SC:Seychelles|SL:Sierra Leone|SG:Singapore|SK:Slovakia|SI:Slovenia|SB:Solomon Islands|SO:Somalia|ZA:South Africa|SS:South Sudan|ES:Spain|LK:Sri Lanka|SD:Sudan|SR:Suriname|SZ:Swaziland|SE:Sweden|CH:Switzerland|SY:Syria (Syrian Arab Republic)|TW:Taiwan|TJ:Tajikistan|TZ:Tanzania|TH:Thailand|TL:Timor-leste (East Timor)|TG:Togo|TO:Tonga|TT:Trinidad and Tobago|TN:Tunisia|TR:Turkey|TM:Turkmenistan|TV:Tuvalu|UG:Uganda|UA:Ukraine|AE:United Arab Emirates|GB:United Kingdom|US:United States|UY:Uruguay|UZ:Uzbekistan|VU:Vanuatu|VE:Venezuela|VN:Vietnam|YE:Yemen|ZM:Zambia|ZW:Zimbabwe
 DATA_DB_VALUES_0 = Norwegian polar institute:Norwegian Polar Institute|NP Brief Report Series:Norwegian Polar Institute Brief Report Series|NP Report Series:Norwegian Polar Institute Report Series|Meddelelser:Norwegian Polar Institute series 'Meddelelser'

--- a/src/no/npolar/data/api/Labels_en.properties
+++ b/src/no/npolar/data/api/Labels_en.properties
@@ -230,5 +230,17 @@ location.arctic.eastern_barents_sea = Eastern Barents Sea
 location.arctic.northern_barents_sea = Northern Barents Sea
 location.arctic.svalbard.barents\u00f8ya = Svalbard - Barents\u00f8ya
 
+#
+# Time series
+#
+timeseries.unit = Unit
+timeseries.title = Series name
+timeseries.point.error = Error
+timeseries.point.median = Median
+timeseries.point.value.low = Low
+timeseries.point.value.high = High
+timeseries.point.value.min = Min.
+timeseries.point.value.max = Max.
+
 DATA_COUNTRIES_0 = AF:Afghanistan|AL:Albania|DZ:Algeria|AD:Andorra|AO:Angola|AG:Antigua and Barbuda|AR:Argentina|AM:Armenia|AU:Australia|AT:Austria|AZ:Azerbaijan|BS:Bahamas|BH:Bahrain|BD:Bangladesh|BB:Barbados|BY:Belarus|BE:Belgium|BZ:Belize|BJ:Benin|BT:Bhutan|BO:Bolivia|BA:Bosnia and Herzegovina|BW:Botswana|BR:Brazil|BN:Brunei|BG:Bulgaria|BF:Burkina Faso|BI:Burundi|KH:Cambodia|CM:Cameroon|CA:Canada|CV:Cape Verde|CF:Central African Republic|TD:Chad|CL:Chile|CN:China|CO:Colombia|KM:Comoros|CG:Congo, Republic of the (Congo-Brazzaville)|CD:Congo, The Democratic Republic of The (Congo-Kinshasa)|CK:Cook Islands|CR:Costa Rica|CI:Cote D'ivoire|HR:Croatia|CU:Cuba|CY:Cyprus|CZ:Czech Republic|DK:Denmark|DJ:Djibouti|DM:Dominica|DO:Dominican Republic|EC:Ecuador|EG:Egypt|SV:El Salvador|GQ:Equatorial Guinea|ER:Eritrea|EE:Estonia|ET:Ethiopia|FJ:Fiji|FI:Finland|FR:France|GA:Gabon|GM:Gambia|GE:Georgia|DE:Germany|GH:Ghana|GR:Greece|GD:Grenada|GT:Guatemala|GN:Guinea|GW:Guinea-Bissau|GY:Guyana|HT:Haiti|VA:Vatican City State (Holy See)|HN:Honduras|HU:Hungary|IS:Iceland|IN:India|ID:Indonesia|IR:Iran|IQ:Iraq|IE:Ireland|IL:Israel|IT:Italy|JM:Jamaica|JP:Japan|JO:Jordan|KZ:Kazakhstan|KE:Kenya|KI:Kiribati|KP:Korea, Democratic People's Republic of (North)|KR:Korea, Republic of|XK:Kosovo|KW:Kuwait|KG:Kyrgyzstan|LA:Lao People's Democratic Republic (Laos)|LV:Latvia|LB:Lebanon|LS:Lesotho|LR:Liberia|LY:Libya|LI:Liechtenstein|LT:Lithuania|LU:Luxembourg|MK:Macedonia|MG:Madagascar|MW:Malawi|MY:Malaysia|MV:Maldives|ML:Mali|MT:Malta|MH:Marshall Islands|MR:Mauritania|MU:Mauritius|MX:Mexico|FM:Micronesia, Federated States of|MD:Moldova, Republic of|MC:Monaco|MN:Mongolia|ME:Montenegro|MA:Morocco|MZ:Mozambique|MM:Myanmar|NA:Namibia|NR:Nauru|NP:Nepal|NL:Netherlands|NZ:New Zealand|NI:Nicaragua|NE:Niger|NG:Nigeria|NU:Niue|NO:Norway|OM:Oman|PK:Pakistan|PW:Palau|PS:Palestine|PA:Panama|PG:Papua New Guinea|PY:Paraguay|PE:Peru|PH:Philippines|PL:Poland|PT:Portugal|QA:Qatar|RO:Romania|RU:Russia|RW:Rwanda|KN:Saint Kitts and Nevis|LC:Saint Lucia|VC:Saint Vincent and The Grenadines|WS:Samoa|SM:San Marino|ST:Sao Tome and Principe|SA:Saudi Arabia|SN:Senegal|RS:Serbia|SC:Seychelles|SL:Sierra Leone|SG:Singapore|SK:Slovakia|SI:Slovenia|SB:Solomon Islands|SO:Somalia|ZA:South Africa|SS:South Sudan|ES:Spain|LK:Sri Lanka|SD:Sudan|SR:Suriname|SZ:Swaziland|SE:Sweden|CH:Switzerland|SY:Syria (Syrian Arab Republic)|TW:Taiwan|TJ:Tajikistan|TZ:Tanzania|TH:Thailand|TL:Timor-leste (East Timor)|TG:Togo|TO:Tonga|TT:Trinidad and Tobago|TN:Tunisia|TR:Turkey|TM:Turkmenistan|TV:Tuvalu|UG:Uganda|UA:Ukraine|AE:United Arab Emirates|GB:United Kingdom|US:United States|UY:Uruguay|UZ:Uzbekistan|VU:Vanuatu|VE:Venezuela|VN:Vietnam|YE:Yemen|ZM:Zambia|ZW:Zimbabwe
 DATA_DB_VALUES_0 = Norwegian polar institute:Norwegian Polar Institute|Norsk Polarinstitutt:Norwegian Polar Institute|Norsk polarinstitutt:Norwegian Polar Institute|NP Brief Report Series:Norwegian Polar Institute Brief Report Series|NP Report Series:Norwegian Polar Institute Report Series|Meddelelser:Norwegian Polar Institute series 'Meddelelser'

--- a/src/no/npolar/data/api/Labels_no.properties
+++ b/src/no/npolar/data/api/Labels_no.properties
@@ -230,5 +230,17 @@ location.arctic.eastern_barents_sea = \u00d8stlige Barentshavet
 location.arctic.northern_barents_sea = Nordlige Barentshavet
 location.arctic.svalbard.barents\u00f8ya = Svalbard - Barents\u00f8ya
 
+#
+# Time series
+#
+timeseries.unit = Enhet
+timeseries.title = Serienavn
+timeseries.point.error = Feilmargin
+timeseries.point.median = Median
+timeseries.point.value.low = Lav
+timeseries.point.value.high = H\u00f8y
+timeseries.point.value.min = Min.
+timeseries.point.value.max = Maks.
+
 DATA_COUNTRIES_0 = AF:Afghanistan|AL:Albania|DZ:Algerie|AD:Andorra|AO:Angola|AG:Antigua and Barbuda|AR:Argentina|AM:Armenia|AU:Australia|AT:&Oslash;sterrike|AZ:Azerbadjan|BS:Bahamas|BH:Bahrain|BD:Bangladesh|BB:Barbados|BY:Hviterussland|BE:Belgia|BZ:Belize|BJ:Benin|BT:Bhutan|BO:Bolivia|BA:Bosnia-Herzegovina|BW:Botswana|BR:Brazil|BN:Brunei|BG:Bulgaria|BF:Burkina Faso|BI:Burundi|KH:Kambodsja|CM:Kamerun|CA:Canada|CV:Kapp Verde|CF:Sentralafrikanske Republikk|TD:Chad|CL:Chile|CN:Kina|CO:Colombia|KM:Comoros|CG:Kongo, republikk (Brazzaville)|CD:Kongo, demokratisk republikk (Kinshasa)|CK:Cook Islands|CR:Costa Rica|CI:Elfenbenskysten|HR:Kroatia|CU:Cuba|CY:Kypros|CZ:Tsjekkoslovakia|DK:Danmark|DJ:Djibouti|DM:Dominica|DO:Dominikanske republikk|EC:Ecuador|EG:Egypt|SV:El Salvador|GQ:Equatorial Guinea|ER:Eritrea|EE:Estland|ET:Etiopia|FJ:Fiji|FI:Finland|FR:Frankrike|GA:Gabon|GM:Gambia|GE:Georgia|DE:Tyskland|GH:Ghana|GR:Hellas|GD:Grenada|GT:Guatemala|GN:Guinea|GW:Guinea-Bissau|GY:Guyana|HT:Haiti|VA:Vatikanstaten (Holy See)|HN:Honduras|HU:Ungarn|IS:Iceland|IN:India|ID:Indonesia|IR:Iran|IQ:Irak|IE:Ireland|IL:Israel|IT:Italia|JM:Jamaica|JP:Japan|JO:Jordan|KZ:Kazakhstan|KE:Kenya|KI:Kiribati|KP:Nord-Korea|KR:S&oslash;r-Korea|XK:Kosovo|KW:Kuwait|KG:Kirgistan|LA:Laos|LV:Latvia|LB:Libanon|LS:Lesotho|LR:Liberia|LY:Libya|LI:Liechtenstein|LT:Litauen|LU:Luxembourg|MK:Makedonia|MG:Madagaskar|MW:Malawi|MY:Malaysia|MV:Maldivene|ML:Mali|MT:Malta|MH:Marshall&oslash;yene|MR:Mauritania|MU:Mauritius|MX:Mexico|FM:Micronesia|MD:Moldova|MC:Monaco|MN:Mongolia|ME:Montenegro|MA:Marokko|MZ:Mosambik|MM:Myanmar|NA:Namibia|NR:Nauru|NP:Nepal|NL:Nederland|NZ:New Zealand|NI:Nicaragua|NE:Niger|NG:Nigeria|NU:Niue|NO:Norge|OM:Oman|PK:Pakistan|PW:Palau|PS:Palestina|PA:Panama|PG:Papua New Guinea|PY:Paraguay|PE:Peru|PH:Filippinene|PL:Polen|PT:Portugal|QA:Qatar|RO:Romania|RU:Russland|RW:Rwanda|KN:Saint Kitts og Nevis|LC:Saint Lucia|VC:Saint Vincent og Grenadinene|WS:Samoa|SM:San Marino|ST:Sao Tome og Principe|SA:Saudi Arabia|SN:Senegal|RS:Serbia|SC:Seychellene|SL:Sierra Leone|SG:Singapore|SK:Slovakia|SI:Slovenia|SB:Salomon&oslash;yene|SO:Somalia|ZA:S&oslash;r-Afrika|SS:S&oslash;r-Sudan|ES:Spania|LK:Sri Lanka|SD:Sudan|SR:Surinam|SZ:Swaziland|SE:Sverige|CH:Sveits|SY:Syria|TW:Taiwan|TJ:Tadsjikistan|TZ:Tanzania|TH:Thailand|TL:Timor-leste (&Oslash;st-Timor)|TG:Togo|TO:Tonga|TT:Trinidad og Tobago|TN:Tunisia|TR:Tyrkia|TM:Turkmenistan|TV:Tuvalu|UG:Uganda|UA:Ukraina|AE:Forente Arabiske Emirater|GB:Storbritannia|US:USA|UY:Uruguay|UZ:Uzbekistan|VU:Vanuatu|VE:Venezuela|VN:Vietnam|YE:Yemen|ZM:Zambia|ZW:Zimbabwe
 DATA_DB_VALUES_0 = Norwegian polar institute:Norsk Polarinstitutt|Norwegian Polar Institute:Norsk Polarinstitutt|NP Brief Report Series:Norsk Polarinstitutt Kortrapportserie|NP Report Series:Norsk Polarinstitutt Rapportserie|Meddelelser:Norsk Polarinstitutts Meddelelser

--- a/src/no/npolar/data/api/MOSJService.java
+++ b/src/no/npolar/data/api/MOSJService.java
@@ -22,7 +22,7 @@ import org.apache.commons.logging.LogFactory;
 /**
  * Provides an interface to read MOSJ-specific data from the Norwegian Polar 
  * Institute Data Centre.
- * 
+ * <p>
  * ToDo: In addition to this MOSJ-specific service, there should be an agnostic, 
  *  generic class TimeSeriesService / MonitoringService. This class could then 
  *  probably extend that one.
@@ -34,10 +34,10 @@ public class MOSJService extends APIService {
     /** The URL path to use when accessing the service. */
     public static final String SERVICE_PATH = "indicator/";
     
-    /** The URL path addon for time series entries. */
+    /** The URL path add-on for time series entries. */
     public static final String SERVICE_PATH_TIMESERIES = "timeseries/";
     
-    /** The URL path addon for time series entries. */
+    /** The URL path add-on for time series entries. */
     public static final String SERVICE_PATH_PARAMETER = "parameter/";
     
     /** Translations. */

--- a/src/no/npolar/data/api/Publication.java
+++ b/src/no/npolar/data/api/Publication.java
@@ -730,6 +730,8 @@ public class Publication implements APIEntryInterface {
     
     /**
      * Gets the default link for this publication.
+     * 
+     * @param baseUrl The base URL, that is, the URL of the service.
      * @return The default link for this publication, or an empty string if none.
      */
     public String getPubLink(String baseUrl) {

--- a/src/no/npolar/data/api/TimeSeriesTimestamp.java
+++ b/src/no/npolar/data/api/TimeSeriesTimestamp.java
@@ -1,0 +1,440 @@
+package no.npolar.data.api;
+
+import java.text.SimpleDateFormat;
+import java.util.Comparator;
+import java.util.Date;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+//import org.apache.commons.lang.builder.HashCodeBuilder;
+
+/**
+ * A time series timestamp (or "time marker") describes a point in time.
+ * <p>
+ * The different types (see the TYPE_XXX constants) indicates the 
+ * accuracy/resolution of the timestamp.
+ * <p>
+ * Timestamps of "literal" type are used literally as-is, e.g. "2007/2008".
+ * <p>
+ * Tested on time series stored in the NPIDC. These time series use date or year.
+ * 
+ * @author Paul-Inge Flakstad, Norwegian Polar Institute <flakstad at npolar.no>
+ */
+public class TimeSeriesTimestamp implements Comparable<TimeSeriesTimestamp> {
+    /** Comparator that can be used to sort timestamps chronologically. */
+    public static final Comparator<TimeSeriesTimestamp> CHRONOLOGICAL = new Comparator<TimeSeriesTimestamp>() {
+        @Override
+        public int compare(TimeSeriesTimestamp o1, TimeSeriesTimestamp o2) {
+            //if ((o1.getType() == TYPE_LITERAL && o2.getType() == TYPE_LITERAL) 
+            //        || (o1.getType() != TYPE_LITERAL && o2.getType() != TYPE_LITERAL)) {
+                return o1.toString().compareTo(o2.toString());
+            //} else {
+                //throw new UnsupportedOperationException("A literal timestamp cannot be compared to a non-literal one.");
+            //}
+        }
+    };
+    /** The default time of day, used if missing. */
+    public static final String DEFAULT_CLOCKTIME = "12:00:00";
+    /** The default day of month (date), used if missing. */
+    public static final String DEFAULT_DAY_OF_MONTH = "01";
+    /** The default month of year (month), used if missing. */
+    public static final String DEFAULT_MONTH_OF_YEAR = "01";
+    /** Date addon: appended to date-only timestamps to create complete timestamps (down to the second). See {@link #PATTERN_TIME_STANDARD}. */
+    public static final String ADDON_FOR_DATE = "T" + DEFAULT_CLOCKTIME + "Z";
+    /** Month addon: appended to month-only timestamps to create complete timestamps (down to the second). See {@link #PATTERN_TIME_STANDARD}. */
+    public static final String ADDON_FOR_MONTH = "-" + DEFAULT_DAY_OF_MONTH + ADDON_FOR_DATE;
+    /** Year addon: appended to year-only timestamps to create complete timestamps (down to the second). See {@link #PATTERN_TIME_STANDARD}. */
+    public static final String ADDON_FOR_YEAR = "-" + DEFAULT_MONTH_OF_YEAR + ADDON_FOR_MONTH;
+    
+    /** This date format pattern describes how this class represents a complete, "standard" timestamp. */
+    public static final String PATTERN_TIME_STANDARD = "yyyy-MM-dd'T'HH:mm:ss'Z'"; // 1871-06-01T12:00:00Z
+    /** This class' "standard" date format, uses {@link #PATTERN_TIME_STANDARD}. */
+    public static final SimpleDateFormat DATE_FORMAT_STANDARD = new SimpleDateFormat(PATTERN_TIME_STANDARD);
+    /** Supported timestamp patterns. Note that the order is important here, index must correspond to the TYPE_XXXX integer value. */
+    public static final String[] PATTERNS_SUPPORTED = new String[] { 
+        "yyyy",
+        "yyyy-MM",
+        "yyyy-MM-dd",
+        PATTERN_TIME_STANDARD
+    };
+    /** Timestamp type: year. The value must equal the corresponding patterns index in {@link #PATTERNS_SUPPORTED}. */
+    public static final int TYPE_YEAR = 0;
+    /** Timestamp type: month. The value must equal the corresponding patterns index in {@link #PATTERNS_SUPPORTED}. */
+    public static final int TYPE_MONTH = 1;
+    /** Timestamp type: date. The value must equal the corresponding patterns index in {@link #PATTERNS_SUPPORTED}. */
+    public static final int TYPE_DATE = 2;
+    /** Timestamp type: time (down to the second). The value must equal the corresponding patterns index in {@link #PATTERNS_SUPPORTED}. */
+    public static final int TYPE_TIME = 3;
+    /** Timestamp type: literal (use as-is). */
+    public static final int TYPE_LITERAL = 99;
+    /** Timestamp type: unknown. */
+    public static final int TYPE_UNKNOWN = Integer.MIN_VALUE;
+    
+    /** Holds the standard timestamp. */
+    private String timestamp = null;
+    /** Holds the original timestamp. */
+    private String original = null;
+    /** Holds the year. */
+    private int year = Integer.MIN_VALUE;
+    /** Holds the type. */
+    private int type = TYPE_UNKNOWN;
+    /** Holds the time. */
+    private Date time = null;
+    //private String utcDate = null;
+    /** Holds the native date format. */
+    private SimpleDateFormat nativeDateFormat = null;
+    /** The logger. */
+    private static final Log LOG = LogFactory.getLog(TimeSeriesTimestamp.class);
+    
+    /**
+     * Creates a new timestamp, based on the given year.
+     * <p>
+     * The resulting timestamp will represent 1 Jan of that year.
+     * 
+     * @param year The year.
+     */
+    public TimeSeriesTimestamp(int year) {
+        this.original = String.valueOf(year);
+        this.year = year;
+        timestamp = "" + this.year + ADDON_FOR_YEAR;
+        type = TYPE_YEAR;
+    }
+    
+    /**
+     * Creates a new timestamp, based on the given long value.
+     * 
+     * @see java.util.Date#setTime() 
+     * @param millis The long representation of a date(time).
+     */
+    public TimeSeriesTimestamp(long millis) {
+        this.original = String.valueOf(millis);
+        Date tempDate = new Date(millis);
+        timestamp = DATE_FORMAT_STANDARD.format(tempDate);
+        year = Integer.parseInt(timestamp.substring(0, 4));
+        type = TYPE_TIME;
+    }
+    
+    /**
+     * Creates a new timestamp of the given type.
+     * <p>
+     * Knowing the type improves performance, as it does not have to be sniffed.
+     * 
+     * @param timestamp The timestamp.
+     * @param type The timestamp type.
+     */
+    public TimeSeriesTimestamp(String timestamp, int type) {
+        this.original = timestamp;
+        this.type = type;
+        
+        // Handle case: a "real" type was given but the actual timestamp 
+        // was a literal (like e.g. "2015/2016")
+        if (this.type != TYPE_LITERAL && this.type != TYPE_UNKNOWN) {
+            try {
+                if (PATTERNS_SUPPORTED[this.type].length() != timestamp.length())  {
+                    this.type = TYPE_LITERAL;
+                }
+            } catch (Exception e) {
+                this.type = TYPE_LITERAL;
+            }
+        }
+        
+        if (this.type != TYPE_LITERAL && this.type != TYPE_UNKNOWN) {
+            this.timestamp = timestamp + getDefaultAddon(type);
+        } else {
+            this.timestamp = timestamp;
+        }
+    }
+    
+    /**
+     * Creates a new timestamp.
+     * <p>
+     * The timestamp type is determined by sniffing the given timestamp. This  
+     * may cause a performance hit, so consider using 
+     * {@link #TimeSeriesTimestamp(java.lang.String, int)} whenever the type is 
+     * known in advance.
+     * 
+     * @param timestamp The timestamp.
+     */
+    public TimeSeriesTimestamp(String timestamp) {
+        this.type = TYPE_UNKNOWN;
+        this.original = timestamp;
+        
+        for (int i = PATTERNS_SUPPORTED.length-1; i >= 0; i--) {
+            
+            try {
+                if (timestamp.length() != PATTERNS_SUPPORTED[i].length()) {
+                    continue;
+                }
+                // Rely on the parse attempt failing if the pattern does not match
+                new SimpleDateFormat(PATTERNS_SUPPORTED[i]).parse(timestamp);
+                
+                // Reaching this point => parse did not fail 
+                type = i; // Relies on a match between types and the index of the corresponding pattern in the "supported patterns" array
+                if (type == TYPE_TIME) {
+                    this.timestamp = timestamp;
+                } else if (type != TYPE_LITERAL && type != TYPE_UNKNOWN) {
+                    //this.timestamp = DATE_FORMAT_STANDARD.format(DATE_FORMAT_STANDARD.parse(timestamp + getDefaultAddon(type)));
+                    this.timestamp = timestamp + getDefaultAddon(type);
+                }
+                break;
+            } catch (Exception e) {}
+        }
+        
+        if (type < 0) {
+            // Means no supported patterns matched => assume literal (e.g. "2002/2003")
+            type = TYPE_LITERAL;
+            this.timestamp = timestamp;
+        }
+        /*
+        if (type >= TYPE_YEAR && type <= TYPE_TIME) {
+            try {
+                // Create the utc date
+                if (type == TYPE_YEAR) {
+                    utcDate = original + ",0,1";
+                } else if (type == TYPE_MONTH) {
+                    String[] timestampParts = original.split("-");
+                    utcDate = "" + timestampParts[0] + "," + (Integer.parseInt(timestampParts[1])-1) + ",1";
+                } else {
+                    String[] timestampParts = original.substring(0,10).split("-");
+                    utcDate = "" + timestampParts[0] + "," + (Integer.parseInt(timestampParts[1])-1) + "," + timestampParts[2];
+                }
+            } catch (Exception e) {
+                //System.out.println("ERROR creating UTC date string: " + e.getMessage());
+            }
+        }
+        */
+    }
+    
+    /**
+     * Gets the string that needs to be appended to timestamps of the given type, 
+     * in order to turn them into "complete" timestamps (accurate down to the 
+     * second).
+     * 
+     * @param type The timestamp type. See the TYPE_XXX constants.
+     * @return The string that needs to be appended to timestamps of the given type, in order to "complete" them.
+     */
+    private String getDefaultAddon(int type) {
+        if (type == TYPE_DATE) {
+            return ADDON_FOR_DATE;
+        }
+        if (type == TYPE_MONTH) {
+            return ADDON_FOR_MONTH;
+        }
+        if (type == TYPE_YEAR) {
+            return ADDON_FOR_YEAR;
+        }
+        return "";
+    }
+    
+    /**
+     * Gets the type for this timestamp.
+     * 
+     * @return The type for this timestamp.
+     */
+    public int getType() {
+        return this.type;
+    }
+    
+    /*public Date getTime(SimpleDateFormat dateFormat) throws ParseException {
+        SimpleDateFormat df = dateFormat;
+        if (df == null) {
+            df = DATE_FORMAT_STANDARD;
+        } else {
+            df.parse(timestamp); // Validity check for given date format (throw exception HERE if invalid)
+        }
+        
+        try {
+            return df.parse(timestamp);
+        } catch (Exception e) {
+            return null;
+        }
+    }*/
+    
+    /**
+     * Gets a {@link java.util.Date} representation of this timestamp. 
+     * <p>
+     * The returned date represents 1 Jan 12:00:00 (or any partial time piece 
+     * therein) for timestamps that are not originally defined down to the 
+     * second.
+     * 
+     * @return A {@link java.util.Date} representation of this timestamp. 
+     */
+    public Date getTime() {
+        if (time == null) {
+            try { 
+                time = DATE_FORMAT_STANDARD.parse(timestamp);
+                return time;
+            } catch (Exception e) {
+                return null;
+            }
+        } else {
+            return time;
+        }
+        /*try {
+            return getTime(null);
+        } catch (Exception e) {
+            return null;
+        }*/
+    }
+    
+    /**
+     * Gets the original timestamp, as provided when this instance was created.
+     * 
+     * @return The original timestamp, as provided when this instance was created.
+     */
+    public String getOriginal() {
+        return original;
+    }
+    
+    /*
+    public String getUTCDate() {
+        return utcDate;
+    }
+    */
+    
+    /**
+     * Gets the native date format pattern, that is, the pattern that is 
+     * consistent with what the original timestamp string actually looks like.
+     * 
+     * @return The native date format pattern.
+     */
+    public String getNativeDateFormatPattern() {
+        if (this.getType() == TYPE_LITERAL) {
+            return "'" + this.timestamp + "'";
+        }
+        else if (this.getType() == TYPE_UNKNOWN) {
+            return "'NO DATE'";
+        } else {
+            try {
+                return PATTERNS_SUPPORTED[this.getType()];
+            } catch (Exception e ) {
+                return null;
+            }
+        }
+    }
+    
+    /**
+     * @return True if this timestamp is of type year, false otherwise.
+     */
+    public boolean isYearType() {
+        return this.getType() == TYPE_YEAR;
+    }
+    
+    /**
+     * @return True if this timestamp is of the given type, false otherwise.
+     */
+    public boolean isType(int type) {
+        return this.getType() == type;
+    }
+    
+    /** 
+     * @return True if this timestamp is more precise than the given type, false otherwise.
+     */
+    public boolean isMorePreciseThan(int type) {
+        return this.getType() > type;
+    }
+    
+    /** 
+     * @return True if this timestamp is of type literal, false otherwise. 
+     */
+    public boolean isLiteralType() {
+        return this.getType() == TYPE_LITERAL;
+    }
+    
+    @Override
+    public String toString() {
+        //System.out.println("Type is " + this.getType() + ", original is '" + original + "'.");
+        if (isLiteralType()) {
+            return getOriginal();
+        }
+        return format(getNativeDateFormat());
+    }
+    
+    /**
+     * Formats the timestamp using the given date format.
+     * 
+     * @param returnFormat The format to apply.
+     * @return The timestamp, formatted using the given date format.
+     */
+    public String toString(SimpleDateFormat returnFormat) {
+        if (isLiteralType())
+            return getOriginal();
+        return format(returnFormat);
+    }
+    
+    /**
+     * Formats the timestamp using the given date format.
+     * 
+     * @param returnFormat The format to apply.
+     * @return The timestamp, formatted using the given date format.
+     */
+    public String format(SimpleDateFormat returnFormat) {
+        try {
+            return returnFormat.format(this.getTime());
+        } catch (Exception e) {
+            return timestamp; // Literal
+        }
+    }
+    
+    /**
+     * Formats the timestamp "natively", that is, using the native date format.
+     * <p>
+     * This method is just an alias for the {@link #toString()} method.
+     *
+     * @return The timestamp, formatted using its native date format.
+     */
+    public String formatNatively() {
+        return toString();
+    }
+    
+    /**
+     * Gets the native date format, which should be consistent with what the 
+     * original timestamp string actually looks like.
+     * 
+     * @return The native date format, or <code>null</code> if none can be determined.
+     * @see #getNativeDateFormatPattern() 
+     */
+    public SimpleDateFormat getNativeDateFormat() {
+        if (nativeDateFormat == null) {
+            try {
+                nativeDateFormat = new SimpleDateFormat(getNativeDateFormatPattern());
+            } catch (Exception e) {
+                if (LOG.isErrorEnabled()) {
+                    LOG.error("Cannot determine native date format for timestamp '" + this.original + "'.", e);
+                }
+            }
+        }
+        return nativeDateFormat;
+    }
+    
+    @Override
+    public int compareTo(TimeSeriesTimestamp other) {
+        //return this.toString().compareTo(other.toString());
+        return this.timestamp.compareTo(other.timestamp);
+    }
+    
+    @Override
+    public int hashCode() {
+        /*return new HashCodeBuilder(17, 31). // two randomly chosen prime numbers
+            // if deriving: appendSuper(super.hashCode()).
+            append(timestamp).toHashCode();*/
+        return this.timestamp.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+       if (!(obj instanceof TimeSeriesTimestamp))
+            return false;
+        if (obj == this)
+            return true;
+
+        TimeSeriesTimestamp rhs = (TimeSeriesTimestamp)obj;
+        return this.timestamp.equals(rhs.timestamp);
+    }
+    
+    /**
+     * Determines whether or not this timestamp has a year set.
+     * 
+     * @return True if this timestamp has a year set, false otherwise.
+     */
+    public boolean hasYear() { return this.year > Integer.MIN_VALUE; }
+}

--- a/src/no/npolar/data/api/mosj/Labels.java
+++ b/src/no/npolar/data/api/mosj/Labels.java
@@ -1,35 +1,36 @@
 package no.npolar.data.api.mosj;
 
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.ResourceBundle;
+//import java.util.Map;
+//import java.util.HashMap;
+//import java.util.Locale;
+//import java.util.ResourceBundle;
 
 /**
  * Provides access to human-readable, localized translation strings.
  * 
  * @author Paul-Inge Flakstad, Norwegian Polar Institute
  * @see Labels.properties
+ * @deprecated Everything moved to {@link no.npolar.data.api.Labels}.
  */
 public class Labels {
 
-    /** Chart label: Median value. */
-    public static final String CHART_MEDIAN_0 = "label.chart.median";
-    /** Chart label: Min value. */
-    public static final String CHART_MIN_0 = "label.chart.min";
-    /** Chart label: Max value. */
-    public static final String CHART_MAX_0 = "label.chart.max";
-    /** Chart label: High value. */
-    public static final String CHART_HIGH_0 = "label.chart.high";
-    /** Chart label: Low value. */
-    public static final String CHART_LOW_0 = "label.chart.low";
-    /** Chart label: Error. */
-    public static final String CHART_ERROR_0 = "label.chart.error";
+    //** Chart label: Median value. */
+    //public static final String CHART_MEDIAN_0 = "label.chart.median";
+    //** Chart label: Min value. */
+    //public static final String CHART_MIN_0 = "label.chart.min";
+    //** Chart label: Max value. */
+    //public static final String CHART_MAX_0 = "label.chart.max";
+    //** Chart label: High value. */
+    //public static final String CHART_HIGH_0 = "label.chart.high";
+    //** Chart label: Low value. */
+    //public static final String CHART_LOW_0 = "label.chart.low";
+    //** Chart label: Error. */
+    //public static final String CHART_ERROR_0 = "label.chart.error";
     
-    /** Series label: Unit. */
-    public static final String SERIES_UNIT_0 = "label.series.unit";
-    /** Series label: Series title / name. */
-    public static final String SERIES_TITLE_0 = "label.series.title";
+    //** Series label: Unit. */
+    //public static final String SERIES_UNIT_0 = "label.series.unit";
+    //** Series label: Series title / name. */
+    //public static final String SERIES_TITLE_0 = "label.series.title";
     
     /**
      * Default constructor. Does nothing.
@@ -41,5 +42,5 @@ public class Labels {
      * 
      * @return The bundle name.
      */
-    public static String getBundleName() { return Labels.class.getCanonicalName(); }
+    //public static String getBundleName() { return Labels.class.getCanonicalName(); }
 }


### PR DESCRIPTION
All changes that went into the first published new versions of
MOSJ-related stuff. Most importantly, this is when support for multiple
values per year / handling large data sets was enabled for time series.
Other changes include significant performance tunings (mostly load for
time series), and minor changes like improved comments, code cleanup,
small bugfix(es), etc. Note related commit on MOSJ2015:
802cca4c2ff60ee11d0b63c607f17c93a86d44be
